### PR TITLE
Improve speed and URL sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Ported Features
 * Uses CTRL-C to stop current crawler stages and save the status.
 * Export the files identified in separate files and the errors and failed requests.
 * Uses beautifulsoup4 for finding absolute and relative links.
+* Implemented HEAD method for analyzing file types before crawling. This feature improves the speed of the crawler significantly.
+* Does not crawl non-html files.
   
 Unported features
 ========
-* Implemented HEAD method for analyzing file types before crawling. This feature improves the speed of the crawler significantly.
 * Identifies non-html files and shows them.
-* Does not crawl non-html files.
 * Identifies directory indexing.
 * Crawl directories with indexing (not yet implemented in v1.0)
 * Identifies all kinds of files by reading the content-type header field of the response.

--- a/lib/fetch_website.py
+++ b/lib/fetch_website.py
@@ -1,24 +1,37 @@
-import requests
 from requests.models import Response
 from requests.auth import HTTPBasicAuth
+import requests
 
 def fetch_website(req_session, url, username=None, password=None):
     """
     Connects to a website and retrieves its content.
 
+    :param req_session: A requests Session object.
     :param url: URL of the website to connect to.
     :param username: Optional username for basic authentication.
     :param password: Optional password for basic authentication.
-    :return: A dictionary containing the response content, status code, and any redirection URL.
+    :return: A response object.
     """
     try:
         # Basic authentication if username and password are provided
         auth = HTTPBasicAuth(username, password) if username and password else None
 
-        # Making a GET request to the website
-        response = req_session.get(url, auth=auth, allow_redirects=False, timeout=5) # 5 seconds timeout
+        # Making a HEAD request to check content type
+        head_response = req_session.head(url, auth=auth, allow_redirects=False, timeout=5)
 
-        return response
+        # Check if the content type is HTML
+        if 'text/html' in head_response.headers.get('Content-Type', ''):
+            # If it's a redirection, return the head response
+            if head_response.headers.get('Location', None) is not None:
+                return head_response
+            else:
+                # Making a GET request if content is HTML
+                response = req_session.get(url, auth=auth, allow_redirects=False, timeout=5)
+                return response
+        else:
+            # Return the HEAD response if not HTML
+            return head_response
+
     except requests.RequestException as e:
-        # Catching any request-related errors
+        # Return an empty Response object in case of error
         return Response()

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -4,6 +4,43 @@ functionality of the web crawler
 """
 import pickle
 from collections import deque
+from urllib.parse import urlparse
+
+
+def is_valid_url(url):
+    """
+    Validates if the given URL has a valid format.
+
+    :param url: URL to validate.
+    :return: True if the URL is valid, False otherwise.
+    """
+    parsed = urlparse(url)
+    return bool(parsed.scheme) and bool(parsed.netloc)
+
+
+def add_url_to_queue(url, url_queue):
+    """
+    Adds a URL to the queue after validating and normalizing it, and ensuring it's not a duplicate.
+
+    :param url: URL to add.
+    :param url_queue: Queue (deque) to add the URL to.
+    """
+    url = url.strip().lower()
+    if is_valid_url(url):
+        url_queue.append(url)
+
+
+def add_url_to_set(url, url_set):
+    """
+    Adds a URL to the set after validating and normalizing it.
+
+    :param url: URL to add.
+    :param url_set: Set to add the URL to.
+    """
+    url = url.strip().lower()
+    if is_valid_url(url) and url not in url_set:
+        url_set.add(url)
+
 
 def store_set_to_file(set_to_save_to_disk, output_directory, file_name):
     """


### PR DESCRIPTION
- The URLs are sanitized before they are added to the queue. If they are not valid, they are not added.
- A new HEAD request is made before the GET when a URL is crawled to get the content type and status code. If the answer is a redirect or the content is not HTML then the GET request is not done. This speeds up the crawling considerably.